### PR TITLE
Add text-to-embed.py

### DIFF
--- a/inference/text-to-embed.py
+++ b/inference/text-to-embed.py
@@ -2,20 +2,27 @@
 from ast import literal_eval
 import os
 import json
-import os
 import pandas as pd
 import torch
 from transformers import LongformerTokenizer, LongformerModel
 from unidecode import unidecode
 import pandas as pd
 from typing import Union
+from sys import argv, stdin
+from hashlib import sha1
+
+model_location = (
+    os.path.dirname(os.path.realpath(__file__)) + os.path.sep + 'model'
+    if '--local' in argv
+    else '/function/model'
+)
 
 # Load tokenizer and model from local, pretrained model files
-tokenizer = LongformerTokenizer.from_pretrained('/function/model',
-                                                local_files_only=True,
-                                                model_max_length=2000)
-model = LongformerModel.from_pretrained('/function/model',
-                                        local_files_only=True)
+tokenizer = LongformerTokenizer.from_pretrained( model_location,
+                                                 local_files_only=True,
+                                                 model_max_length=2000 )
+
+model = LongformerModel.from_pretrained(model_location, local_files_only=True)
 
 # Get longformer embedding
 def get_embedding(text:str):
@@ -54,9 +61,12 @@ def handler(event, context):
 
     # Found event_text, use it and return result
     try:
-        res = get_embedding(event_text)
         result['statusCode'] = 200
-        result['body']['msg'] = str(res)
+        result['msg'] = 'Success'
+        result['body']['embedding'] = {
+          'vector': get_embedding(event_text).detach().tolist(),
+          'from_text_hash': sha1(event_text.encode('utf-8')).hexdigest()
+        }
         result['headers']['Content-Type'] = "application/json"
     except:
         result['statusCode'] = 500
@@ -64,3 +74,5 @@ def handler(event, context):
         result['headers']['Content-Type'] = "application/json"
     return json.dumps(result)
 
+if '--local' in argv:
+    print(handler({'body': json.dumps({'text': stdin.read()})}, None))

--- a/inference/text-to-embed.py
+++ b/inference/text-to-embed.py
@@ -1,0 +1,66 @@
+# Imports
+from ast import literal_eval
+import os
+import json
+import os
+import pandas as pd
+import torch
+from transformers import LongformerTokenizer, LongformerModel
+from unidecode import unidecode
+import pandas as pd
+from typing import Union
+
+# Load tokenizer and model from local, pretrained model files
+tokenizer = LongformerTokenizer.from_pretrained('/function/model',
+                                                local_files_only=True,
+                                                model_max_length=2000)
+model = LongformerModel.from_pretrained('/function/model',
+                                        local_files_only=True)
+
+# Get longformer embedding
+def get_embedding(text:str):
+    inp = tokenizer(text,\
+                    padding="longest",\
+                    truncation="longest_first",\
+                    return_tensors="pt")
+    return model(**inp).last_hidden_state[0][0]
+
+# Define lambda handler
+def handler(event, context):
+    # Starting point for response formatting
+    result = {
+        "isBase64Encoded": False,
+        "statusCode": 500,
+        "headers": {"Content-Type": "application/json"},
+        "multiValueHeaders": {},
+        "body": {"warnings": []}
+    }
+
+    # Get input from body or query string
+    if ('text' in event):
+        event_text = event['text']
+    elif ('body' in event and event['body'] != '' and 'text' in json.loads(event['body'])):
+        event_text = json.loads(event['body'])['text']
+    elif ('queryStringParameters' in event and 'text' in event['queryStringParameters']):
+        event_text = event['queryStringParameters']['text']
+    else:
+        result['statusCode'] = 500
+        result['body'] = {'msg': 'Error! Valid input text not provided!'}
+        result['headers']['Content-Type'] = "application/json"
+        return json.dumps(result)
+
+    # Handle unicode in event_text
+    event_text = unidecode(event_text)
+
+    # Found event_text, use it and return result
+    try:
+        res = get_embedding(event_text)
+        result['statusCode'] = 200
+        result['body']['msg'] = str(res)
+        result['headers']['Content-Type'] = "application/json"
+    except:
+        result['statusCode'] = 500
+        result['body']['warnings'].append("Error occurred while processing input text!")
+        result['headers']['Content-Type'] = "application/json"
+    return json.dumps(result)
+


### PR DESCRIPTION
This adds an endpoint modeled on `text-to-db-similar.py`, only returning the embedding instead of the related incidents. The same format from #20 is used, including a `vector` and `from_text_hash` field in the response body.

I've only tested this locally using a mock `event` argument, but I expect that it would work on AWS given its similarity to `text-to-db-similar.py`.