### PR TITLE
Add embedding update workflow, catch exceptions

### DIFF
--- a/.github/workflows/embedding_update.yml
+++ b/.github/workflows/embedding_update.yml
@@ -1,0 +1,29 @@
+name: 'Embedding Update'
+
+on:
+  schedule:
+    - cron: "0 6 * * *"
+  workflow_dispatch: {}
+
+jobs:
+  deploy:
+    name: 'Embedding Update'
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Clone the repository
+        run: git clone https://github.com/responsible-ai-collaborative/nlp-lambdas.git
+
+      - name: Install dependencies
+        run: pip3 install -r requirements.txt -r requirements-dev.txt
+        working-directory: ./nlp-lambdas
+
+      - name: Install language model
+        run: git submodule update --init --recursive
+        working-directory: ./nlp-lambdas
+
+      - name: state_update_db.py
+        run: python3 state_update_db.py
+        working-directory: ./nlp-lambdas
+        env:
+          MONGODB_CONNECTION_STRING: ${{ secrets.MONGODB_CONNECTION_STRING }}


### PR DESCRIPTION
- Per [suggestion of running embedding update in GitHub workflow](https://github.com/responsible-ai-collaborative/aiid/pull/1020#issuecomment-1245642819).

- Needs a secret `MONGODB_CONNECTION_STRING` containing the connection string for the database to be updated.

- The workflow [seems to basically work](https://github.com/lmcnulty/aiid-embedding-update-workflow/actions), but the MongoDB connection sometimes gives out, so we need to add `try` / `except` to proceed on failure.